### PR TITLE
Feature/refactor collector

### DIFF
--- a/backend/api/routes/bids.py
+++ b/backend/api/routes/bids.py
@@ -29,12 +29,9 @@ from backend.collector.naramarket import fetch_bids, fetch_bids_by_query
 from backend.collector.service import collect_and_save, save_bids
 from backend.db.crud import (
     count_notices,
-    get_analysis_by_notice_id,
-    get_attachments_by_notice,
     get_dashboard_stats,
     get_notice_detail,
     get_notices,
-    get_risk_factors_by_notice,
     get_type_stats,
     search_notices,
     set_bookmark,
@@ -543,12 +540,9 @@ async def get_bid_detail(
     notice = await get_notice_detail(db, bid_ntce_no)
     if not notice:
         raise HTTPException(status_code=404, detail="공고를 찾을 수 없습니다.")
-    attachments = await get_attachments_by_notice(db, notice.id)
-    analysis = await get_analysis_by_notice_id(db, notice.id)
-    risk_factors = await get_risk_factors_by_notice(db, notice.id)
     response = BidDetailResponse.model_validate(notice)
     response.is_expired = bool(notice.bid_clse_dt and notice.bid_clse_dt < datetime.now(KST))
-    response.attachments = [AttachmentSchema.model_validate(a) for a in attachments]
-    response.analysis_result = AnalysisResultSchema.model_validate(analysis) if analysis else None
-    response.risk_factors = [RiskFactorSchema.model_validate(r) for r in risk_factors]
+    response.attachments = [AttachmentSchema.model_validate(a) for a in notice.attachments]
+    response.analysis_result = AnalysisResultSchema.model_validate(notice.analysis_result) if notice.analysis_result else None
+    response.risk_factors = [RiskFactorSchema.model_validate(r) for r in notice.risk_factors]
     return response

--- a/backend/api/routes/bids.py
+++ b/backend/api/routes/bids.py
@@ -25,15 +25,14 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.collector.naramarket import fetch_bids, fetch_bids_by_query
-from backend.collector.naramarket import _classify_notice_type
-from backend.collector.service import collect_and_save
+
+from backend.collector.service import collect_and_save, save_bids
 from backend.db.crud import (
     count_notices,
     get_analysis_by_notice_id,
     get_attachments_by_notice,
     get_dashboard_stats,
     get_notice_detail,
-    get_notice_by_bid_no,
     get_notices,
     get_risk_factors_by_notice,
     get_type_stats,
@@ -423,7 +422,6 @@ async def toggle_in_progress(
 def preview_collect(
     start_date: str | None = None,
     end_date: str | None = None,
-    it_only: bool = True,
 ) -> BidPreviewResponse:
     """오늘 날짜 기준으로 나라장터 공고를 수집하여 미리보기 결과를 반환한다."""
     today = date.today().strftime("%Y%m%d")
@@ -431,7 +429,7 @@ def preview_collect(
     end = end_date or today
 
     try:
-        results = fetch_bids(start, end, it_only)
+        results = fetch_bids(start, end)
     except (ValueError, RuntimeError) as e:
         raise HTTPException(status_code=502, detail=str(e))
 
@@ -464,7 +462,6 @@ def preview_collect(
 async def collect_bids(
     start_date: str | None = None,
     end_date: str | None = None,
-    it_only: bool = True,
     download: bool = False,
     db: AsyncSession = Depends(get_db),
 ) -> CollectResponse:
@@ -475,7 +472,7 @@ async def collect_bids(
 
     try:
         result = await collect_and_save(
-            db, start, end, it_only=it_only, download=download
+            db, start, end, download=download
         )
     except (ValueError, RuntimeError) as e:
         raise HTTPException(status_code=502, detail=str(e))
@@ -524,47 +521,7 @@ async def search_bids(
         return SearchResponse(source="empty", results=[], total=0)
 
     # 3단계: 검색 결과 DB 저장 (중복 제외)
-    from datetime import datetime, timezone
-
-    for r in raw:
-        bid = r["bid"]
-        existing = await get_notice_by_bid_no(
-            db, bid["bid_ntce_no"], bid["bid_ntce_ord"]
-        )
-        if existing:
-            continue
-        notice_type, is_isp_ismp, isp_ismp_type = _classify_notice_type(
-            bid["bid_ntce_nm"]
-        )
-        from backend.collector.service import _parse_dt
-
-        try:
-            notice = Notice(
-                bid_ntce_no=bid["bid_ntce_no"],
-                bid_ntce_ord=bid["bid_ntce_ord"],
-                notice_type=notice_type,
-                bid_ntce_nm=bid["bid_ntce_nm"],
-                ntce_instt_nm=bid["ntce_instt_nm"],
-                dminstt_nm=bid["dminstt_nm"],
-                bid_mtd_nm=bid["bid_mtd_nm"],
-                cntrct_cncls_mthd_nm=bid["cntrct_cncls_mthd_nm"],
-                is_isp_ismp=is_isp_ismp,
-                isp_ismp_type=isp_ismp_type,
-                presmpt_prce=bid["presmpt_prce"],
-                asign_bdgt_amt=bid["asign_bdgt_amt"],
-                bid_clse_dt=_parse_dt(bid["bid_clse_dt"]),
-                bid_ntce_dt=_parse_dt(bid["bid_ntce_dt"]),
-                openg_dt=_parse_dt(bid["openg_dt"]),
-                ntce_kind_nm=bid.get("ntce_kind_nm"),
-                bid_ntce_dtl_url=bid["bid_ntce_dtl_url"],
-                pipeline_status="collected",
-                collected_at=datetime.now(timezone.utc),
-            )
-            from backend.db.crud import create_notice
-
-            await create_notice(db, notice)
-        except Exception:
-            pass
+    await save_bids(db, raw)
 
     # 저장 후 DB에서 재조회하여 반환
     notices = await search_notices(db, q)

--- a/backend/collector/naramarket.py
+++ b/backend/collector/naramarket.py
@@ -22,7 +22,7 @@ BID_LIST_URL = (
 
 # 단독 키워드 — 공고명에 있으면 바로 포함 (업종코드 무관)
 STANDALONE_KEYWORDS = [
-    "ISP", "ISMP", "BPR", "PI",
+    "ISP", "ISMP", "BPR",
     "정보화전략", "정보화계획", "디지털전환", "마스터플랜", "IT 컨설팅",
 ]
 

--- a/backend/collector/naramarket.py
+++ b/backend/collector/naramarket.py
@@ -7,7 +7,6 @@
 """
 
 import os
-from datetime import datetime
 
 import requests
 from dotenv import load_dotenv
@@ -16,98 +15,37 @@ load_dotenv()
 
 API_KEY = os.getenv("NARA_API_KEY", "")
 
-# 나라장터 입찰공고 목록 API
+# 전체 용역 공고 조회 — 업종코드 무관하게 ISP/ISMP 누락 방지
 BID_LIST_URL = (
     "https://apis.data.go.kr/1230000/ad/BidPublicInfoService/getBidPblancListInfoServc"
 )
 
-# 단독으로 걸리는 키워드 — 공고명에 있으면 컨설팅 여부 무관하게 포함
+# 단독 키워드 — 공고명에 있으면 바로 포함 (업종코드 무관)
 STANDALONE_KEYWORDS = [
-    "ISP",
-    "ISMP",
-    "정보화전략",
-    "정보화계획",
-    "디지털전환",
+    "ISP", "ISMP", "BPR", "PI",
+    "정보화전략", "정보화계획", "디지털전환", "마스터플랜", "IT 컨설팅",
 ]
 
-# "컨설팅"과 함께 있어야 걸리는 IT 관련 키워드
+# 트리거 단어와 함께 있어야 걸리는 IT 키워드
 CONSULTING_KEYWORDS = [
-    "IT",
-    "ICT",
-    "SW",
-    "AI",
-    "인공지능",
-    "정보",
-    "디지털",
-    "클라우드",
-    "보안",
-    "사이버",
-    "시스템",
-    "ERP",
-    "데이터",
-    "DX",
+    "IT", "ICT", "SW", "AI", "인공지능",
+    "정보", "디지털", "클라우드", "보안", "사이버",
+    "시스템", "ERP", "데이터", "DX",
 ]
+
+# 분류용 — ISMP 판별 (ISP보다 먼저 검사 — "ISMP"에 "ISP"가 포함됨)
+ISMP_KEYWORDS = ["ISMP", "마스터플랜", "정보시스템마스터플랜"]
+
+# 분류용 — ISP 판별
+ISP_KEYWORDS = ["ISP", "정보화전략", "정보화계획"]
+
+# 분류용 — BPR/PI 판별
+BPR_PI_KEYWORDS = ["BPR", "PI"]
 
 
 # ──────────────────────────────────────
 # 내부 필터 함수
 # ──────────────────────────────────────
-
-
-# 주의: 이 함수의 키워드를 수정하면 _classify_notice_type()도 함께 확인할 것
-def _is_it_consulting(item: dict) -> bool:
-    """IT 컨설팅 공고인지 2단계 키워드 로직으로 판별한다."""
-    name = item.get("bidNtceNm", "")
-    name_lower = name.lower()
-
-    # 1) 단독 키워드가 공고명에 있으면 바로 포함
-    if any(kw.lower() in name_lower for kw in STANDALONE_KEYWORDS):
-        return True
-
-    # 2) 트리거 단어 + IT 관련 키워드가 동시에 있으면 포함
-    trigger = (
-        "컨설팅" in name_lower
-        or "계획 수립" in name_lower
-        or "기본계획" in name_lower
-        or "마스터플랜" in name_lower
-    )
-    if trigger:
-        if any(kw.lower() in name_lower for kw in CONSULTING_KEYWORDS):
-            return True
-
-    return False
-
-
-def _classify_notice_type(bid_ntce_nm: str) -> tuple[str, bool, str | None]:
-    """
-    공고명을 분석하여 공고 유형을 분류한다.
-
-    Returns:
-        (notice_type, is_isp_ismp, isp_ismp_type)
-        - notice_type  : "ISP" | "ISMP" | "일반"
-        - is_isp_ismp  : ISP 또는 ISMP 여부
-        - isp_ismp_type: "ISP" | "ISMP" | None
-    """
-    name_lower = bid_ntce_nm.lower()
-
-    # ISMP 판별 (ISP보다 먼저 검사 — "ISMP"에 "ISP"가 포함되어 있기 때문)
-    if (
-        "ismp" in name_lower
-        or "정보시스템마스터플랜" in name_lower
-        or "마스터플랜" in name_lower
-    ):
-        return "ISMP", True, "ISMP"
-
-    # ISP 판별
-    if (
-        "isp" in name_lower
-        or "정보화전략" in name_lower
-        or "정보화계획" in name_lower
-    ):
-        return "ISP", True, "ISP"
-
-    # 일반 IT 컨설팅 (필터는 통과했으나 ISP/ISMP 키워드 없음)
-    return "일반", False, None
 
 
 def _is_service_bid(item: dict) -> bool:
@@ -124,6 +62,53 @@ def _safe_int(value: int | str | None) -> int | None:
         return None
 
 
+def _is_it_consulting(item: dict) -> bool:
+    """IT 컨설팅 공고인지 2단계 키워드 로직으로 판별한다."""
+    name_lower = item.get("bidNtceNm", "").lower()
+
+    # 1단계: 단독 키워드가 있으면 바로 포함
+    if any(kw.lower() in name_lower for kw in STANDALONE_KEYWORDS):
+        return True
+
+    # 2단계: 트리거 단어 + IT 키워드 조합
+    trigger = (
+        "컨설팅" in name_lower
+        or "계획 수립" in name_lower
+        or "기본계획" in name_lower
+    )
+    if trigger and any(kw.lower() in name_lower for kw in CONSULTING_KEYWORDS):
+        return True
+
+    return False
+
+
+def _classify_notice_type(bid_ntce_nm: str) -> tuple[str, bool, str | None]:
+    """
+    공고명을 분석하여 공고 유형을 분류한다.
+
+    Returns:
+        (notice_type, is_isp_ismp, isp_ismp_type)
+        - notice_type  : "ISP" | "ISMP" | "BPR/PI" | "일반"
+        - is_isp_ismp  : ISP 또는 ISMP 여부
+        - isp_ismp_type: "ISP" | "ISMP" | None
+    """
+    name_lower = bid_ntce_nm.lower()
+
+    # ISMP 판별 (ISP보다 먼저 검사 — "ISMP"에 "ISP"가 포함됨)
+    if any(kw.lower() in name_lower for kw in ISMP_KEYWORDS):
+        return "ISMP", True, "ISMP"
+
+    # ISP 판별
+    if any(kw.lower() in name_lower for kw in ISP_KEYWORDS):
+        return "ISP", True, "ISP"
+
+    # BPR/PI 판별
+    if any(kw.lower() in name_lower for kw in BPR_PI_KEYWORDS):
+        return "BPR/PI", False, None
+
+    return "일반", False, None
+
+
 # ──────────────────────────────────────
 # 데이터 변환 함수
 # ──────────────────────────────────────
@@ -131,10 +116,13 @@ def _safe_int(value: int | str | None) -> int | None:
 
 def parse_bid(item: dict) -> dict:
     """API 응답 단건을 DB 저장용 딕셔너리로 변환한다."""
+    bid_ntce_nm = item.get("bidNtceNm", "")
+    notice_type, is_isp_ismp, isp_ismp_type = _classify_notice_type(bid_ntce_nm)
+
     return {
         "bid_ntce_no": item.get("bidNtceNo", ""),
         "bid_ntce_ord": item.get("bidNtceOrd", ""),  # 입찰공고차수 (재공고 판별)
-        "bid_ntce_nm": item.get("bidNtceNm", ""),
+        "bid_ntce_nm": bid_ntce_nm,
         "ntce_instt_nm": item.get("ntceInsttNm", ""),  # 공고기관명
         "dminstt_nm": item.get("dminsttNm", ""),  # 수요기관명
         "bid_clse_dt": item.get("bidClseDt", ""),  # 입찰마감일시 ★
@@ -151,6 +139,9 @@ def parse_bid(item: dict) -> dict:
         "is_canceled": "취소" in item.get("ntceKindNm", ""),
         "is_corrected": "정정" in item.get("ntceKindNm", ""),
         "bid_mtd_nm": item.get("bidMethdNm", ""),  # 입찰방식명
+        "notice_type": notice_type,
+        "is_isp_ismp": is_isp_ismp,
+        "isp_ismp_type": isp_ismp_type,
     }
 
 
@@ -166,8 +157,8 @@ def parse_attachments(item: dict) -> list[dict]:
                 {
                     "file_name": name,
                     "file_url": url,
-                    "file_type": ext,  # pdf / hwp / doc 등
-                    "parse_status": "pending",  # 강현묵이 파싱 후 done으로 변경
+                    "file_type": ext,
+                    "parse_status": "pending",
                 }
             )
     return attachments
@@ -226,56 +217,32 @@ def fetch_bids_by_query(query: str, limit: int = 20) -> list[dict]:
         if "취소" in item.get("ntceKindNm", ""):
             continue
         seen.add(ntce_no)
-        results.append({
-            "bid": parse_bid(item),
-            "attachments": parse_attachments(item),
-        })
+        results.append(
+            {
+                "bid": parse_bid(item),
+                "attachments": parse_attachments(item),
+            }
+        )
 
     return results
 
 
-def fetch_bids(start_date: str, end_date: str, it_only: bool = True) -> list[dict]:
+def _fetch_all_pages(base_params: dict, seen: set[str]) -> list[dict]:
     """
-    나라장터 OpenAPI를 호출하여 공고 목록을 반환한다.
+    주어진 파라미터로 전체 페이지를 순회하며 공고를 수집한다.
 
     Args:
-        start_date : 조회 시작일 YYYYMMDD (예: "20260401")
-        end_date   : 조회 종료일 YYYYMMDD (예: "20260409"), 최대 7일 범위
-        it_only    : True면 IT 컨설팅 공고만, False면 용역 전체
-
-    Returns:
-        [{"bid": {...}, "attachments": [...]}, ...]
-
-    Raises:
-        ValueError: API 키 누락 또는 조회 범위 7일 초과 시
-        RuntimeError: API 호출 실패 시
+        base_params : pageNo를 제외한 공통 API 파라미터
+        seen        : 이미 수집된 공고번호 집합 (중복 제거용, 호출자와 공유)
     """
-    if not API_KEY:
-        raise ValueError(".env에 NARA_API_KEY가 없습니다.")
-
-    # 최대 조회 범위 7일 초과 금지
-    start_dt = datetime.strptime(start_date, "%Y%m%d")
-    end_dt = datetime.strptime(end_date, "%Y%m%d")
-    if (end_dt - start_dt).days > 7:
-        raise ValueError("조회 범위는 최대 7일까지만 허용됩니다.")
-
     results = []
-    seen: set[str] = set()  # 중복 공고 제거용
     page = 1
 
     while True:
-        params = {
-            "serviceKey": API_KEY,
-            "numOfRows": 100,
-            "pageNo": page,
-            "inqryDiv": 1,
-            "inqryBgnDt": start_date + "0000",  # API 날짜 형식: YYYYMMDD0000
-            "inqryEndDt": end_date + "2359",
-            "type": "json",
-        }
-
         try:
-            resp = requests.get(BID_LIST_URL, params=params, timeout=15)
+            resp = requests.get(
+                BID_LIST_URL, params={**base_params, "pageNo": page}, timeout=15
+            )
             resp.raise_for_status()
         except requests.RequestException as e:
             raise RuntimeError(f"API 호출 실패 (page {page}): {e}")
@@ -284,7 +251,6 @@ def fetch_bids(start_date: str, end_date: str, it_only: bool = True) -> list[dic
         total_count = int(body.get("totalCount", 0))
         items = body.get("items", [])
 
-        # 단건일 때 dict로 오는 API 특성 대응
         if isinstance(items, dict):
             items = [items]
         if not items:
@@ -292,20 +258,17 @@ def fetch_bids(start_date: str, end_date: str, it_only: bool = True) -> list[dic
 
         for item in items:
             ntce_no = item.get("bidNtceNo", "")
-            if ntce_no in seen:  # 중복 제거
+            if ntce_no in seen:
                 continue
-            if not _is_service_bid(item):  # 물품·공사 제외
+            if not _is_service_bid(item):
                 continue
-            if "취소" in item.get("ntceKindNm", ""):  # 취소공고 제외
+            if "취소" in item.get("ntceKindNm", ""):
                 continue
-            if it_only and not _is_it_consulting(item):  # IT 필터
+            if not _is_it_consulting(item):
                 continue
             seen.add(ntce_no)
             results.append(
-                {
-                    "bid": parse_bid(item),
-                    "attachments": parse_attachments(item),
-                }
+                {"bid": parse_bid(item), "attachments": parse_attachments(item)}
             )
 
         if page * 100 >= total_count:
@@ -313,3 +276,47 @@ def fetch_bids(start_date: str, end_date: str, it_only: bool = True) -> list[dic
         page += 1
 
     return results
+
+
+def fetch_bids(
+    start_date: str,
+    end_date: str,
+    start_time: str = "0000",
+    end_time: str = "2359",
+) -> list[dict]:
+    """
+    나라장터 전체 용역 공고에서 IT 컨설팅 공고를 수집한다.
+
+    수집 전략 (v3 — 전체 용역 검색, 키워드 필터):
+      1. 업종코드 무관하게 전체 용역 공고 조회 — ISP/ISMP 누락 방지
+      2. _is_it_consulting()으로 IT 컨설팅 공고 필터링
+      3. _classify_notice_type()으로 ISP/ISMP/BPR-PI/일반 분류
+      → 모호한 공고는 담당자가 직접 판단
+
+    Args:
+        start_date : 조회 시작일 YYYYMMDD (예: "20260401")
+        end_date   : 조회 종료일 YYYYMMDD (예: "20260409")
+        start_time : 조회 시작 시각 HHMM (기본 "0000")
+        end_time   : 조회 종료 시각 HHMM (기본 "2359")
+
+    Returns:
+        [{"bid": {..., "notice_type": "ISP"|"ISMP"|"BPR/PI"|"일반"}, "attachments": [...]}, ...]
+
+    Raises:
+        ValueError: API 키 누락 시
+        RuntimeError: API 호출 실패 시
+    """
+    if not API_KEY:
+        raise ValueError(".env에 NARA_API_KEY가 없습니다.")
+
+    base_params = {
+        "serviceKey": API_KEY,
+        "numOfRows": 100,
+        "inqryDiv": 1,
+        "inqryBgnDt": start_date + start_time,
+        "inqryEndDt": end_date + end_time,
+        "type": "json",
+    }
+
+    seen: set[str] = set()
+    return _fetch_all_pages(base_params, seen)

--- a/backend/collector/service.py
+++ b/backend/collector/service.py
@@ -5,17 +5,21 @@
 naramarket.py에서 공고를 가져와 DB에 저장하는 공통 로직.
 - POST /bids/collect 엔드포인트
 - APScheduler 자동 수집
-두 곳 모두 이 함수를 호출한다.
+- 검색 결과 저장 (search_bids)
+세 곳 모두 이 파일을 호출한다.
 """
 
+import logging
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 KST = timezone(timedelta(hours=9))
 
+logger = logging.getLogger(__name__)
+
 from backend.collector.file_downloader import download_attachments
-from backend.collector.naramarket import _classify_notice_type, fetch_bids
+from backend.collector.naramarket import fetch_bids
 from backend.db.crud import create_attachments, create_notice, get_notice_by_bid_no
 from backend.db.models import Notice
 
@@ -32,56 +36,46 @@ def _parse_dt(value: str | None) -> datetime | None:
     return None
 
 
-async def collect_and_save(
+async def save_bids(
     db: AsyncSession,
-    start_date: str,
-    end_date: str,
-    it_only: bool = True,
+    results: list[dict],
     download: bool = False,
 ) -> dict:
     """
-    나라장터 공고를 수집하여 DB에 저장한다.
+    naramarket.py에서 반환된 공고 목록을 DB에 저장한다.
 
     Args:
-        db         : DB 세션
-        start_date : 수집 시작일 (YYYYMMDD)
-        end_date   : 수집 종료일 (YYYYMMDD)
-        it_only    : IT 컨설팅 공고만 필터링 여부
-        download   : 첨부파일 다운로드 여부
+        db      : DB 세션
+        results : fetch_bids / fetch_bids_by_query 반환값
+        download: 첨부파일 다운로드 여부
 
     Returns:
         {"saved": int, "skipped": int, "errors": int}
     """
-    results = fetch_bids(start_date, end_date, it_only)
     saved = skipped = errors = 0
 
     for r in results:
         bid = r["bid"]
 
-        # 중복 체크 — 이미 DB에 있으면 건너뜀
         existing = await get_notice_by_bid_no(db, bid["bid_ntce_no"], bid["bid_ntce_ord"])
         if existing:
             skipped += 1
             continue
 
-        # ISP/ISMP 유형 분류
-        notice_type, is_isp_ismp, isp_ismp_type = _classify_notice_type(bid["bid_ntce_nm"])
-
-        # 첨부파일 다운로드 (download=True 일 때만 실행)
         downloaded = download_attachments(r["attachments"]) if download else r["attachments"]
 
         try:
             notice = Notice(
                 bid_ntce_no=bid["bid_ntce_no"],
                 bid_ntce_ord=bid["bid_ntce_ord"],
-                notice_type=notice_type,
+                notice_type=bid["notice_type"],
                 bid_ntce_nm=bid["bid_ntce_nm"],
                 ntce_instt_nm=bid["ntce_instt_nm"],
                 dminstt_nm=bid["dminstt_nm"],
                 bid_mtd_nm=bid["bid_mtd_nm"],
                 cntrct_cncls_mthd_nm=bid["cntrct_cncls_mthd_nm"],
-                is_isp_ismp=is_isp_ismp,
-                isp_ismp_type=isp_ismp_type,
+                is_isp_ismp=bid["is_isp_ismp"],
+                isp_ismp_type=bid["isp_ismp_type"],
                 presmpt_prce=bid["presmpt_prce"],
                 asign_bdgt_amt=bid["asign_bdgt_amt"],
                 bid_clse_dt=_parse_dt(bid["bid_clse_dt"]),
@@ -94,7 +88,6 @@ async def collect_and_save(
             )
             await create_notice(db, notice)
 
-            # 전체 첨부파일 저장
             now = datetime.now(timezone.utc)
             attachment_rows = [
                 {
@@ -112,6 +105,33 @@ async def collect_and_save(
 
             saved += 1
         except Exception:
+            logger.exception("공고 저장 실패: %s", bid.get("bid_ntce_no", "unknown"))
             errors += 1
 
     return {"saved": saved, "skipped": skipped, "errors": errors}
+
+
+async def collect_and_save(
+    db: AsyncSession,
+    start_date: str,
+    end_date: str,
+    start_time: str = "0000",
+    end_time: str = "2359",
+    download: bool = False,
+) -> dict:
+    """
+    나라장터 공고를 수집하여 DB에 저장한다.
+
+    Args:
+        db         : DB 세션
+        start_date : 수집 시작일 (YYYYMMDD)
+        end_date   : 수집 종료일 (YYYYMMDD)
+        start_time : 조회 시작 시각 HHMM (기본 "0000")
+        end_time   : 조회 종료 시각 HHMM (기본 "2359")
+        download   : 첨부파일 다운로드 여부
+
+    Returns:
+        {"saved": int, "skipped": int, "errors": int}
+    """
+    results = fetch_bids(start_date, end_date, start_time, end_time)
+    return await save_bids(db, results, download)

--- a/backend/db/crud.py
+++ b/backend/db/crud.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from .models import AnalysisResult, Attachment, Notice, ProposalOutline, RiskFactor
 
@@ -18,6 +19,11 @@ async def get_notice_detail(db: AsyncSession, bid_ntce_no: str) -> Notice | None
     """공고번호로 가장 최신 차수의 공고 상세를 반환한다."""
     result = await db.execute(
         select(Notice)
+        .options(
+            selectinload(Notice.attachments),
+            selectinload(Notice.analysis_result),
+            selectinload(Notice.risk_factors),
+        )
         .where(Notice.bid_ntce_no == bid_ntce_no)
         .order_by(Notice.bid_ntce_ord.desc())
         .limit(1)
@@ -103,7 +109,7 @@ async def get_notices(
         date_to,
         search,
     )
-    query = query.order_by(Notice.bid_clse_dt.asc()).limit(limit).offset(offset)
+    query = query.order_by(Notice.collected_at.desc()).limit(limit).offset(offset)
     result = await db.execute(query)
     return result.scalars().all()
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,8 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from backend.api.routes import bids, analysis, search
 
+SCHEDULE_HOURS = [10, 13, 16, 20]
+
 
 def collect_today():
     """스케줄러가 호출하는 자동 수집 함수 — 오늘 날짜 공고를 자동 수집한다."""
@@ -23,20 +25,39 @@ def collect_today():
     asyncio.run(_run())
 
 
-def collect_recent_sync(days: int = 7):
-    """서버 시작 후 최근 N일치 공고를 한 번 수집한다."""
+def collect_gap():
+    """서버 시작 시 마지막 스케줄 수집 이후 현재까지의 빈틈을 수집한다."""
     import asyncio
-    from datetime import date, timedelta
+    from datetime import datetime, timedelta
     from backend.collector.service import collect_and_save
     from backend.db.database import AsyncSessionLocal
 
-    end = date.today()
-    start = end - timedelta(days=days - 1)
+    now = datetime.now()
+    # 오늘 스케줄 시각 목록
+    today_slots = [
+        now.replace(hour=h, minute=0, second=0, microsecond=0)
+        for h in SCHEDULE_HOURS
+    ]
+    # 현재 시각 이전인 슬롯 중 가장 최근 → 직전 수집 시각
+    past_slots = [t for t in today_slots if t <= now]
+    if past_slots:
+        last_slot = past_slots[-1]
+    else:
+        # 오늘 첫 스케줄(10:00) 이전 → 어제 마지막 슬롯(20:00)
+        yesterday = now - timedelta(days=1)
+        last_slot = yesterday.replace(hour=SCHEDULE_HOURS[-1], minute=0, second=0, microsecond=0)
+
+    start_date = last_slot.strftime("%Y%m%d")
+    start_time = last_slot.strftime("%H%M")
+    end_date = now.strftime("%Y%m%d")
+    end_time = now.strftime("%H%M")
 
     async def _run():
         async with AsyncSessionLocal() as db:
-            result = await collect_and_save(db, start.strftime("%Y%m%d"), end.strftime("%Y%m%d"))
-            print(f"[초기 수집] 최근 {days}일치 완료 — 저장: {result['saved']}건 / 중복: {result['skipped']}건 / 오류: {result['errors']}건")
+            result = await collect_and_save(db, start_date, end_date,
+                                            start_time=start_time, end_time=end_time)
+            print(f"[갭 수집] {start_date} {start_time}~{end_date} {end_time} 완료 "
+                  f"— 저장: {result['saved']}건 / 중복: {result['skipped']}건 / 오류: {result['errors']}건")
 
     asyncio.run(_run())
 
@@ -47,10 +68,10 @@ async def lifespan(app: FastAPI):
 
     scheduler = BackgroundScheduler()
     # 매일 정해진 시간 자동 수집
-    for hour in [10, 13, 16, 20]:
+    for hour in SCHEDULE_HOURS:
         scheduler.add_job(collect_today, "cron", hour=hour, minute=0, id=f"collect_{hour}")
-    # 서버 시작 5초 후 최근 7일치 초기 수집 (1회)
-    scheduler.add_job(collect_recent_sync, "date", run_date=datetime.now() + timedelta(seconds=5), id="collect_init")
+    # 서버 시작 5초 후 전일 20:00 이후 빈틈 수집 (1회)
+    scheduler.add_job(collect_gap, "date", run_date=datetime.now() + timedelta(seconds=5), id="collect_init")
     scheduler.start()
     print("[스케줄러] 10:00 13:00 16:00 20:00 공고 수집 시작")
     yield

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 from contextlib import asynccontextmanager
 
-from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -9,36 +9,29 @@ from backend.api.routes import bids, analysis, search
 SCHEDULE_HOURS = [10, 13, 16, 20]
 
 
-def collect_today():
+async def collect_today():
     """스케줄러가 호출하는 자동 수집 함수 — 오늘 날짜 공고를 자동 수집한다."""
-    import asyncio
     from datetime import date
     from backend.collector.service import collect_and_save
     from backend.db.database import AsyncSessionLocal
 
-    async def _run():
-        today = date.today().strftime("%Y%m%d")
-        async with AsyncSessionLocal() as db:
-            result = await collect_and_save(db, today, today)
-            print(f"[스케줄러] 수집 완료 — 저장: {result['saved']}건 / 중복: {result['skipped']}건 / 오류: {result['errors']}건")
-
-    asyncio.run(_run())
+    today = date.today().strftime("%Y%m%d")
+    async with AsyncSessionLocal() as db:
+        result = await collect_and_save(db, today, today)
+        print(f"[스케줄러] 수집 완료 — 저장: {result['saved']}건 / 중복: {result['skipped']}건 / 오류: {result['errors']}건")
 
 
-def collect_gap():
+async def collect_gap():
     """서버 시작 시 마지막 스케줄 수집 이후 현재까지의 빈틈을 수집한다."""
-    import asyncio
     from datetime import datetime, timedelta
     from backend.collector.service import collect_and_save
     from backend.db.database import AsyncSessionLocal
 
     now = datetime.now()
-    # 오늘 스케줄 시각 목록
     today_slots = [
         now.replace(hour=h, minute=0, second=0, microsecond=0)
         for h in SCHEDULE_HOURS
     ]
-    # 현재 시각 이전인 슬롯 중 가장 최근 → 직전 수집 시각
     past_slots = [t for t in today_slots if t <= now]
     if past_slots:
         last_slot = past_slots[-1]
@@ -52,21 +45,18 @@ def collect_gap():
     end_date = now.strftime("%Y%m%d")
     end_time = now.strftime("%H%M")
 
-    async def _run():
-        async with AsyncSessionLocal() as db:
-            result = await collect_and_save(db, start_date, end_date,
-                                            start_time=start_time, end_time=end_time)
-            print(f"[갭 수집] {start_date} {start_time}~{end_date} {end_time} 완료 "
-                  f"— 저장: {result['saved']}건 / 중복: {result['skipped']}건 / 오류: {result['errors']}건")
-
-    asyncio.run(_run())
+    async with AsyncSessionLocal() as db:
+        result = await collect_and_save(db, start_date, end_date,
+                                        start_time=start_time, end_time=end_time)
+        print(f"[갭 수집] {start_date} {start_time}~{end_date} {end_time} 완료 "
+              f"— 저장: {result['saved']}건 / 중복: {result['skipped']}건 / 오류: {result['errors']}건")
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from datetime import datetime, timedelta
 
-    scheduler = BackgroundScheduler()
+    scheduler = AsyncIOScheduler()
     # 매일 정해진 시간 자동 수집
     for hour in SCHEDULE_HOURS:
         scheduler.add_job(collect_today, "cron", hour=hour, minute=0, id=f"collect_{hour}")

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -15,19 +15,23 @@ const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000';
 // ─────────────────────────────────────────────
 
 export interface ApiBidListItem {
+  id: number;
   bid_ntce_no: string;
   bid_ntce_nm: string;
-  ntce_instt_nm: string;
+  ntce_instt_nm: string | null;
+  ntce_kind_nm: string | null;
+  is_isp_ismp: boolean;
+  isp_ismp_type: string | null;
+  is_bookmarked: boolean;
+  is_in_progress: boolean;
+  is_expired: boolean;
   presmpt_prce: number | null;
   asign_bdgt_amt: number | null;
-  bid_clse_dt: string;        // "YYYY-MM-DD" or "YYYY-MM-DDTHH:mm:ss"
-  bid_ntce_dt: string;
-  is_isp_ismp: boolean | null;
-  isp_ismp_type: string | null;
-  pipeline_status: string | null; // "completed" | "processing" | "pending" | "failed"
-  // 선택적: 백엔드가 사전 집계해서 보내줄 수도 있음
-  danger_count?: number;
-  overall_risk?: string;
+  bid_clse_dt: string | null;
+  bid_ntce_dt: string | null;
+  collected_at: string | null;
+  pipeline_status: string;
+  bid_ntce_dtl_url: string | null;
 }
 
 export interface ApiAnalysisResult {
@@ -59,12 +63,9 @@ export interface ApiBidDetailResponse extends ApiBidListItem {
   risk_factors: ApiRiskFactor[];
 }
 
-// 페이지네이션 응답 (백엔드가 래핑할 경우)
 export interface ApiBidListResponse {
-  items: ApiBidListItem[];
   total: number;
-  page: number;
-  per_page: number;
+  bids: ApiBidListItem[];
 }
 
 // ─────────────────────────────────────────────
@@ -94,12 +95,12 @@ function mapBidType(item: ApiBidListItem): BidType {
 }
 
 function mapPipelineStatus(status: string | null): AiStatusType {
-  if (status === 'completed') return 'complete';
-  return 'analyzing';
+  if (status === 'analyzed') return 'complete';
+  if (status === 'analyzing' || status === 'parsing') return 'analyzing';
+  return 'none';
 }
 
-function normalizeDate(dateStr: string): string {
-  // "YYYY-MM-DDTHH:mm:ss" → "YYYY-MM-DD"
+function normalizeDate(dateStr: string | null | undefined): string {
   return dateStr ? dateStr.slice(0, 10) : '';
 }
 
@@ -147,33 +148,36 @@ function mapAnalysisResultToBidDetail(
 }
 
 export function mapApiBidListItemToBid(item: ApiBidListItem): Bid {
-  const budget = item.presmpt_prce ?? item.asign_bdgt_amt ?? 0;
+  const budget = item.asign_bdgt_amt ?? item.presmpt_prce ?? 0;
   return {
-    id: String(item.bid_ntce_no),
+    id: item.bid_ntce_no,
     number: item.bid_ntce_no,
     title: item.bid_ntce_nm,
-    agency: item.ntce_instt_nm,
+    agency: item.ntce_instt_nm ?? '',
     budget,
     deadline: normalizeDate(item.bid_clse_dt),
-    risk: mapRiskLevel([], item.overall_risk),
+    risk: 'good' as RiskLevel,
     aiStatus: mapPipelineStatus(item.pipeline_status),
     type: mapBidType(item),
-    dangerCount: item.danger_count ?? 0,
+    dangerCount: 0,
     collectedAt: normalizeDate(item.bid_ntce_dt),
-    status: 'none',
+    is_bookmarked: item.is_bookmarked,
+    is_in_progress: item.is_in_progress,
+    is_expired: item.is_expired,
+    ntce_dtl_url: item.bid_ntce_dtl_url ?? undefined,
   };
 }
 
 export function mapApiBidDetailToBid(res: ApiBidDetailResponse): Bid {
-  const budget = res.presmpt_prce ?? res.asign_bdgt_amt ?? 0;
+  const budget = res.asign_bdgt_amt ?? res.presmpt_prce ?? 0;
   const riskFactors = (res.risk_factors ?? []).map(mapApiRiskFactor);
-  const risk = mapRiskLevel(res.risk_factors ?? [], res.overall_risk);
+  const risk = mapRiskLevel(res.risk_factors ?? []);
 
   return {
-    id: String(res.bid_ntce_no),
+    id: res.bid_ntce_no,
     number: res.bid_ntce_no,
     title: res.bid_ntce_nm,
-    agency: res.ntce_instt_nm,
+    agency: res.ntce_instt_nm ?? '',
     budget,
     deadline: normalizeDate(res.bid_clse_dt),
     risk,
@@ -181,7 +185,10 @@ export function mapApiBidDetailToBid(res: ApiBidDetailResponse): Bid {
     type: mapBidType(res),
     dangerCount: riskFactors.filter((r) => r.severity === 'high').length,
     collectedAt: normalizeDate(res.bid_ntce_dt),
-    status: 'none',
+    is_bookmarked: res.is_bookmarked,
+    is_in_progress: res.is_in_progress,
+    is_expired: res.is_expired,
+    ntce_dtl_url: res.bid_ntce_dtl_url ?? undefined,
     detail: res.analysis_result
       ? mapAnalysisResultToBidDetail(res.analysis_result, budget)
       : undefined,
@@ -206,8 +213,9 @@ export interface FetchBidsParams {
 export async function fetchBids(params?: FetchBidsParams): Promise<Bid[]> {
   try {
     const url = new URL(`${BASE_URL}/bids`);
-    if (params?.page != null) url.searchParams.set('page', String(params.page));
-    if (params?.per_page != null) url.searchParams.set('per_page', String(params.per_page));
+    url.searchParams.set('limit', String(params?.per_page ?? 100));
+    if (params?.page != null && params?.per_page != null)
+      url.searchParams.set('offset', String((params.page - 1) * params.per_page));
     if (params?.date_from) url.searchParams.set('date_from', params.date_from);
     if (params?.date_to) url.searchParams.set('date_to', params.date_to);
 
@@ -218,11 +226,8 @@ export async function fetchBids(params?: FetchBidsParams): Promise<Bid[]> {
 
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
-    const data: ApiBidListItem[] | ApiBidListResponse = await res.json();
-
-    // 배열 또는 페이지네이션 래퍼 모두 처리
-    const items: ApiBidListItem[] = Array.isArray(data) ? data : data.items;
-    return items.map(mapApiBidListItemToBid);
+    const data: ApiBidListResponse = await res.json();
+    return data.bids.map(mapApiBidListItemToBid);
   } catch (err) {
     console.warn('[api] fetchBids 실패 → mockData fallback:', err);
     return mockBids;
@@ -249,6 +254,18 @@ export async function fetchBidById(id: string): Promise<Bid> {
     if (found) return found;
     throw new Error(`공고 ID ${id}를 찾을 수 없습니다`);
   }
+}
+
+export async function triggerCollect(): Promise<{ saved: number; skipped: number; errors: number }> {
+  const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+  const res = await fetch(`${BASE_URL}/bids/collect`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ start_date: today, end_date: today }),
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
 }
 
 export interface SearchBidsResult {


### PR DESCRIPTION
## 1. 관련 이슈
closes #24 #25 

## 2. 작업 내용
- **수집 엔드포인트 변경**: PPSSrch(업종코드 기반) → 전체 용역 조회(`getBidPblancListInfoServc`)로 변경해 업종코드 누락으로 인한 ISP/ISMP 공고 소실 방지
- **2단계 키워드 필터 적용**: 단독 키워드(ISP, ISMP, BPR, 정보화전략 등) + 트리거+IT 키워드 조합으로 관련 공고 누락 최소화
- **PI false positive 제거**: "PI기반 시스템 구축" 등 관련 없는 공고가 수집되던 문제 수정
- **스케줄러 교체**: `BackgroundScheduler` → `AsyncIOScheduler`로 교체해 이벤트 루프 충돌(500 에러) 수정
- **갭 수집 추가**: 서버 시작 시 마지막 스케줄 이후 현재까지 빈틈 자동 수집
- **공고 목록 정렬 변경**: `bid_clse_dt ASC` → `collected_at DESC`로 변경해 최신 수집 공고 우선 표시
- **공고 상세 DB 중복 조회 제거**: `get_bid_detail`에서 이미 `selectinload`로 로드된 관계를 재조회하던 문제 수정
- **`save_bids` 분리**: 공고 저장 로직을 별도 함수로 추출해 `search_bids` 중복 코드 제거
- **예산 표시 필드 순서 변경**: `presmptPrce` → `asignBdgtAmt` 우선으로 변경 (실제 배정예산 표시)
- **에러 로깅 추가**: 공고 저장 실패 시 에러 내용 로깅

## 3. 체크리스트
- [x] 코드 컨벤션을 준수했습니다
- [x] 셀프 리뷰를 완료했습니다
- [ ] 테스트를 완료했습니다

## 4. 스크린샷 (선택)
<img width="1790" height="930" alt="image" src="https://github.com/user-attachments/assets/669aacdc-5b0a-4d3c-a843-caa5d0724a13" />

