### PR TITLE
schema 정리: attachments DDL 누락 보완 + 제안목차 JSONB 통합

### DIFF
--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import String, Boolean, Numeric, Text, Date, SmallInteger, ForeignKey, TIMESTAMP
+from sqlalchemy import String, Boolean, Numeric, Text, Date, ForeignKey, TIMESTAMP
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 from pgvector.sqlalchemy import Vector
@@ -119,28 +119,10 @@ class ProposalOutline(Base):
     outline_version:       Mapped[int]           = mapped_column(default=1)
     guideline_base:        Mapped[str]           = mapped_column(String(20), default="MOIS_ISP")
     total_pages_estimate:  Mapped[Optional[int]] = mapped_column(nullable=True)
+    sections:              Mapped[list]          = mapped_column(JSONB, default=list)
     model_used:            Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
     prompt_version:        Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
     generated_at:          Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
     is_active:             Mapped[bool]          = mapped_column(Boolean, default=True)
 
     notice:   Mapped["Notice"]               = relationship("Notice", back_populates="proposal_outlines")
-    sections: Mapped[list["ProposalSection"]]= relationship("ProposalSection", back_populates="outline")
-
-
-class ProposalSection(Base):
-    __tablename__ = "proposal_sections"
-
-    id:             Mapped[int]           = mapped_column(primary_key=True)
-    outline_id:     Mapped[int]           = mapped_column(ForeignKey("proposal_outlines.id", ondelete="CASCADE"))
-    level:          Mapped[int]           = mapped_column(SmallInteger)
-    parent_id:      Mapped[Optional[int]] = mapped_column(ForeignKey("proposal_sections.id", ondelete="CASCADE"), nullable=True)
-    sort_order:     Mapped[int]           = mapped_column(default=0)
-    section_no:     Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
-    section_title:  Mapped[str]           = mapped_column(String(300))
-    section_desc:   Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    pages_estimate: Mapped[Optional[int]] = mapped_column(nullable=True)
-    is_mandatory:   Mapped[bool]          = mapped_column(Boolean, default=True)
-
-    outline:  Mapped["ProposalOutline"]       = relationship("ProposalOutline", back_populates="sections")
-    children: Mapped[list["ProposalSection"]] = relationship("ProposalSection")

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -114,6 +114,7 @@ CREATE TABLE proposal_outlines (
     outline_version         INTEGER         NOT NULL DEFAULT 1,
     guideline_base          VARCHAR(20)     NOT NULL DEFAULT 'MOIS_ISP',
     total_pages_estimate    INTEGER,
+    sections                JSONB           NOT NULL DEFAULT '[]'::jsonb,
     model_used              VARCHAR(50),
     prompt_version          VARCHAR(20),
     generated_at            TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
@@ -122,23 +123,6 @@ CREATE TABLE proposal_outlines (
 
 CREATE INDEX idx_proposal_outlines_notice_id ON proposal_outlines (notice_id);
 CREATE INDEX idx_proposal_outlines_is_active ON proposal_outlines (notice_id, is_active);
-
-CREATE TABLE proposal_sections (
-    id                      SERIAL PRIMARY KEY,
-    outline_id              INTEGER         NOT NULL REFERENCES proposal_outlines(id) ON DELETE CASCADE,
-    level                   SMALLINT        NOT NULL CHECK (level BETWEEN 1 AND 4),
-    parent_id               INTEGER         REFERENCES proposal_sections(id) ON DELETE CASCADE,
-    sort_order              INTEGER         NOT NULL DEFAULT 0,
-    section_no              VARCHAR(20),
-    section_title           VARCHAR(300)    NOT NULL,
-    section_desc            TEXT,
-    pages_estimate          INTEGER,
-    is_mandatory            BOOLEAN         NOT NULL DEFAULT TRUE
-);
-
-CREATE INDEX idx_proposal_sections_outline_id ON proposal_sections (outline_id);
-CREATE INDEX idx_proposal_sections_parent_id  ON proposal_sections (parent_id);
-CREATE INDEX idx_proposal_sections_level      ON proposal_sections (outline_id, level, sort_order);
 
 CREATE OR REPLACE FUNCTION update_updated_at()
 RETURNS TRIGGER AS $$

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -45,6 +45,20 @@ CREATE INDEX idx_notices_ntce_instt_nm   ON notices (ntce_instt_nm);
 CREATE INDEX idx_notices_bid_ntce_no     ON notices (bid_ntce_no);
 CREATE INDEX idx_notices_collected_at    ON notices (collected_at DESC);
 
+CREATE TABLE attachments (
+    id            SERIAL PRIMARY KEY,
+    notice_id     INTEGER         NOT NULL REFERENCES notices(id) ON DELETE CASCADE,
+    file_name     VARCHAR(300)    NOT NULL,
+    file_url      TEXT            NOT NULL,
+    file_type     VARCHAR(20)     NOT NULL,
+    local_path    TEXT,
+    parse_status  VARCHAR(20)     NOT NULL DEFAULT 'pending'
+                      CHECK (parse_status IN ('pending','done','failed')),
+    downloaded_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_attachments_notice_id ON attachments (notice_id);
+
 CREATE TABLE analysis_results (
     id                      SERIAL PRIMARY KEY,
     notice_id               INTEGER         NOT NULL REFERENCES notices(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary
schema.sql을 두 가지 측면에서 정리합니다. 커밋 단위로 변경을 분리했어요.

### 커밋 1 — `Fix: attachments 테이블 DDL 누락 보완`
- `attachments` 테이블이 `models.py` / `crud.py` / `collector/service.py` 등에서 사용되지만 `db/schema.sql`에는 누락되어 있었음 (collector PR #26 머지 시점에 빠진 듯)
- 새 환경에서 `psql -f schema.sql` → 백엔드 부팅 → 수집 실행 시 `relation "attachments" does not exist` 에러로 파이프라인이 전혀 동작하지 않음
- DDL은 `models.Attachment` 정의를 그대로 옮긴 형태 + `parse_status` CHECK constraint + `notice_id` 인덱스

### 커밋 2 — `Refactor: 제안목차 트리 정규화 → JSONB 단일 컬럼 통합` (RFC 성격)
`proposal_sections` 테이블을 폐기하고 `proposal_outlines.sections` (JSONB) 한 컬럼으로 통합 제안입니다.

**왜 정규화가 이득이 없는지**

| 항목 | 트리 정규화 (현행) | JSONB 통합 (제안) |
|---|---|---|
| 생성 | 트리 → flatten → N+1 INSERT, parent_id 채워주는 로직 필요 | INSERT 한 번 |
| 조회 | 재귀 CTE 또는 N+1 SELECT → 트리 복원 | `SELECT sections FROM ...` 한 번 |
| 부분 편집 | 가능 (level/sort_order/parent_id 일관성 관리 부담) | 통째로 교체 (사용 패턴상 어차피 통째로 다뤄짐) |
| Excel 내보내기 | DB rows → 트리 복원 → flatten → Excel | JSON → Excel |
| 일관성 관리 | parent_id, level, sort_order 셋이 동시에 정합해야 함 | 트리 무결성은 INSERT 시점에만 검증 |

**제안목차의 실제 사용 패턴**
- 생성: AI가 통째로 트리 전체를 만듦 (부분 생성 없음)
- 표시: 클라이언트에서 트리 통째로 렌더
- 재생성: 기존 트리 다 날리고 새로 생성
- 부분 쿼리 (`level=2인 섹션만`, `is_mandatory 카운트`) 실수요 없음

부분 쿼리 이득이 없는데 정규화의 모든 비용을 짊어지는 구조라 JSONB가 더 적합합니다.

**기존 설계와의 일관성**
`analysis_results`의 `manmonth_detail` / `required_docs` / `contact_person`이 이미 JSONB로 잡혀 있음 → "고정 필드는 정규화 컬럼, 가변/리스트형은 JSONB"라는 기존 모범 사례에 sections만 어긋난 형태였음. 통합 시 일관성 회복.

**호환성**
현재 `proposal_sections`에 실제 데이터가 들어간 곳은 아직 없음 (outline route 미연결 상태) → 무손실 변경.

## Test plan
- [x] `db/schema.sql` 적용 후 `\dt`로 5개 테이블 확인 (attachments 포함, proposal_sections 부재)
- [x] `\d proposal_outlines`로 `sections jsonb NOT NULL DEFAULT '[]'` 확인
- [x] `from backend.main import app` 임포트 통과
- [ ] 강주현님 — `proposal_sections`를 분리한 의도가 있었다면 커밋 2만 revert 가능, 커밋 1은 독립적으로 머지해도 무방합니다

## Notes
- 커밋 2가 RFC 성격이라 이견 있으시면 PR 코멘트로 의견 부탁드려요
- 머지되면 후속 PR에서 `outline_service`가 이 JSONB 컬럼에 저장하도록 작성 + outline 라우트 신설 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)