### PR TITLE
analysis_results를 AI 출력 구조로 재설계 + risk_factors 통합

### DIFF
--- a/backend/api/routes/analysis.py
+++ b/backend/api/routes/analysis.py
@@ -13,7 +13,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.db.crud import (
     get_analysis_by_notice_id,
     get_notice_detail,
-    get_risk_factors_by_notice,
     update_pipeline_status,
 )
 from backend.db.database import get_db
@@ -81,12 +80,10 @@ async def get_analysis(
         raise HTTPException(status_code=404, detail="공고를 찾을 수 없습니다.")
 
     analysis = await get_analysis_by_notice_id(db, notice.id)
-    risk_factors = await get_risk_factors_by_notice(db, notice.id)
 
     return {
         "bid_ntce_no": bid_ntce_no,
         "pipeline_status": notice.pipeline_status,
         "analysis_result": analysis,
-        "risk_factors": risk_factors,
     }
 

--- a/backend/api/routes/bids.py
+++ b/backend/api/routes/bids.py
@@ -155,7 +155,7 @@ class AnalysisResultSchema(BaseModel):
     project_scope: str | None = None
     qualification: str | None = None
     eval_criteria: list | None = None
-    requirements: list | None = None
+    requirements: dict | None = None
     tech_requirements: list | None = None
     poison_clauses: dict | None = None
     raw_analysis: dict | None = None

--- a/backend/api/routes/bids.py
+++ b/backend/api/routes/bids.py
@@ -141,47 +141,27 @@ class BidListResponse(BaseModel):
 
 
 class AnalysisResultSchema(BaseModel):
-    """AI 분석 결과 스키마"""
+    """AI 분석 결과 스키마. 독소조항은 poison_clauses JSONB에 포함."""
 
-    budget_amt: float | None = None
-    budget_raw: str | None = None
-    bid_qualify: str | None = None
-    exec_period_months: int | None = None
-    exec_period_raw: str | None = None
-    manmonth_total: float | None = None
-    manmonth_detail: dict | None = None
-    past_performance: str | None = None
-    eval_tech_score: float | None = None
-    eval_price_score: float | None = None
-    task_scope: str | None = None
-    joint_supply_yn: bool | None = None
-    joint_supply_detail: str | None = None
+    project_type: str | None = None
+    estimated_price: int | None = None
+    allocated_budget: int | None = None
+    project_duration: str | None = None
+    contract_method: str | None = None
     submit_deadline: datetime | None = None
-    required_docs: dict | None = None
-    exec_location: str | None = None
-    key_tech_spec: str | None = None
-    disqualify_reason: str | None = None
-    contact_person: dict | None = None
-    confidence_score: float | None = None
+    risk_level: str | None = None
+    issuing_org: str | None = None
+    project_summary: str | None = None
+    project_scope: str | None = None
+    qualification: str | None = None
+    eval_criteria: list | None = None
+    requirements: list | None = None
+    tech_requirements: list | None = None
+    poison_clauses: dict | None = None
+    raw_analysis: dict | None = None
     model_used: str | None = None
+    analysis_status: str | None = None
     analyzed_at: datetime | None = None
-
-    class Config:
-        from_attributes = True
-
-
-class RiskFactorSchema(BaseModel):
-    """위험 요인 단건 스키마"""
-
-    id: int
-    risk_category: str
-    risk_level: str
-    clause_title: str | None = None
-    clause_original: str | None = None
-    clause_summary: str
-    page_no: int | None = None
-    mitigation_suggest: str | None = None
-    sort_order: int = 0
 
     class Config:
         from_attributes = True
@@ -215,7 +195,6 @@ class BidDetailResponse(BaseModel):
     collected_at: datetime | None
     attachments: list[AttachmentSchema] = []
     analysis_result: AnalysisResultSchema | None = None
-    risk_factors: list[RiskFactorSchema] = []
 
     class Config:
         from_attributes = True
@@ -544,5 +523,4 @@ async def get_bid_detail(
     response.is_expired = bool(notice.bid_clse_dt and notice.bid_clse_dt < datetime.now(KST))
     response.attachments = [AttachmentSchema.model_validate(a) for a in notice.attachments]
     response.analysis_result = AnalysisResultSchema.model_validate(notice.analysis_result) if notice.analysis_result else None
-    response.risk_factors = [RiskFactorSchema.model_validate(r) for r in notice.risk_factors]
     return response

--- a/backend/db/crud.py
+++ b/backend/db/crud.py
@@ -4,7 +4,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from .models import AnalysisResult, Attachment, Notice, ProposalOutline, RiskFactor
+from .models import AnalysisResult, Attachment, Notice, ProposalOutline
 
 KST = timezone(timedelta(hours=9))
 
@@ -22,7 +22,6 @@ async def get_notice_detail(db: AsyncSession, bid_ntce_no: str) -> Notice | None
         .options(
             selectinload(Notice.attachments),
             selectinload(Notice.analysis_result),
-            selectinload(Notice.risk_factors),
         )
         .where(Notice.bid_ntce_no == bid_ntce_no)
         .order_by(Notice.bid_ntce_ord.desc())
@@ -241,23 +240,6 @@ async def upsert_analysis(db: AsyncSession, notice_id: int, data: dict):
         db.add(existing)
     await db.commit()
     return existing
-
-
-# risk_factors
-async def get_risk_factors_by_notice(db: AsyncSession, notice_id: int):
-    result = await db.execute(
-        select(RiskFactor)
-        .where(RiskFactor.notice_id == notice_id)
-        .order_by(RiskFactor.sort_order)
-    )
-    return result.scalars().all()
-
-
-async def create_risk_factors(db: AsyncSession, notice_id: int, factors: list[dict]):
-    objs = [RiskFactor(notice_id=notice_id, **f) for f in factors]
-    db.add_all(objs)
-    await db.commit()
-    return objs
 
 
 async def get_type_stats(db: AsyncSession) -> list[dict]:

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -80,7 +80,7 @@ class AnalysisResult(Base):
     project_scope:     Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
     qualification:     Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
     eval_criteria:     Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
-    requirements:      Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
+    requirements:      Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
     tech_requirements: Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
     poison_clauses:    Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
 

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import String, Boolean, Numeric, Text, Date, ForeignKey, TIMESTAMP
+from sqlalchemy import String, Boolean, Numeric, Text, Date, BigInteger, ForeignKey, TIMESTAMP
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 from pgvector.sqlalchemy import Vector
@@ -41,7 +41,6 @@ class Notice(Base):
 
     attachments:       Mapped[list["Attachment"]]       = relationship("Attachment", back_populates="notice", cascade="all, delete-orphan")
     analysis_result:   Mapped["AnalysisResult"]         = relationship("AnalysisResult", back_populates="notice", uselist=False)
-    risk_factors:      Mapped[list["RiskFactor"]]       = relationship("RiskFactor", back_populates="notice")
     proposal_outlines: Mapped[list["ProposalOutline"]]  = relationship("ProposalOutline", back_populates="notice")
 
 
@@ -63,52 +62,37 @@ class Attachment(Base):
 class AnalysisResult(Base):
     __tablename__ = "analysis_results"
 
-    id:                  Mapped[int]            = mapped_column(primary_key=True)
-    notice_id:           Mapped[int]            = mapped_column(ForeignKey("notices.id", ondelete="CASCADE"), unique=True)
-    budget_amt:          Mapped[Optional[float]]= mapped_column(Numeric(18, 2), nullable=True)
-    budget_raw:          Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
-    bid_qualify:         Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
-    exec_period_months:  Mapped[Optional[int]]  = mapped_column(nullable=True)
-    exec_period_raw:     Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
-    manmonth_total:      Mapped[Optional[float]]= mapped_column(Numeric(8, 2), nullable=True)
-    manmonth_detail:     Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
-    past_performance:    Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
-    eval_tech_score:     Mapped[Optional[float]]= mapped_column(Numeric(5, 2), nullable=True)
-    eval_price_score:    Mapped[Optional[float]]= mapped_column(Numeric(5, 2), nullable=True)
-    task_scope:          Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
-    joint_supply_yn:     Mapped[Optional[bool]] = mapped_column(nullable=True)
-    joint_supply_detail: Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
-    submit_deadline:     Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
-    required_docs:       Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
-    exec_location:       Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
-    key_tech_spec:       Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
-    disqualify_reason:   Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
-    contact_person:      Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
-    confidence_score:    Mapped[Optional[float]]= mapped_column(Numeric(4, 3), nullable=True)
-    model_used:          Mapped[Optional[str]]  = mapped_column(String(50), nullable=True)
-    prompt_version:      Mapped[Optional[str]]  = mapped_column(String(20), nullable=True)
-    analyzed_at:         Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
-    updated_at:          Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+    id:                Mapped[int]            = mapped_column(primary_key=True)
+    notice_id:         Mapped[int]            = mapped_column(ForeignKey("notices.id", ondelete="CASCADE"), unique=True)
+
+    # 정형
+    project_type:      Mapped[Optional[str]]  = mapped_column(String(20), nullable=True)
+    estimated_price:   Mapped[Optional[int]]  = mapped_column(BigInteger, nullable=True)
+    allocated_budget:  Mapped[Optional[int]]  = mapped_column(BigInteger, nullable=True)
+    project_duration:  Mapped[Optional[str]]  = mapped_column(String(50), nullable=True)
+    contract_method:   Mapped[Optional[str]]  = mapped_column(String(100), nullable=True)
+    submit_deadline:   Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+    risk_level:        Mapped[Optional[str]]  = mapped_column(String(10), nullable=True)
+
+    # 텍스트 / 반정형
+    issuing_org:       Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
+    project_summary:   Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
+    project_scope:     Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
+    qualification:     Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
+    eval_criteria:     Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
+    requirements:      Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
+    tech_requirements: Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
+    poison_clauses:    Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
+
+    # 메타
+    raw_analysis:      Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
+    model_used:        Mapped[Optional[str]]  = mapped_column(String(50), nullable=True)
+    prompt_version:    Mapped[Optional[str]]  = mapped_column(String(20), nullable=True)
+    analysis_status:   Mapped[str]            = mapped_column(String(20), default="pending")
+    analyzed_at:       Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+    updated_at:        Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
 
     notice: Mapped["Notice"] = relationship("Notice", back_populates="analysis_result")
-
-
-class RiskFactor(Base):
-    __tablename__ = "risk_factors"
-
-    id:                  Mapped[int]           = mapped_column(primary_key=True)
-    notice_id:           Mapped[int]           = mapped_column(ForeignKey("notices.id", ondelete="CASCADE"))
-    risk_category:       Mapped[str]           = mapped_column(String(50))
-    risk_level:          Mapped[str]           = mapped_column(String(10), default="medium")
-    clause_title:        Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
-    clause_original:     Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    clause_summary:      Mapped[str]           = mapped_column(Text)
-    page_no:             Mapped[Optional[int]] = mapped_column(nullable=True)
-    mitigation_suggest:  Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    sort_order:          Mapped[int]           = mapped_column(default=0)
-    created_at:          Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
-
-    notice: Mapped["Notice"] = relationship("Notice", back_populates="risk_factors")
 
 
 class ProposalOutline(Base):

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -59,54 +59,45 @@ CREATE TABLE attachments (
 
 CREATE INDEX idx_attachments_notice_id ON attachments (notice_id);
 
+-- AI 분석 결과. AI 파트(강현묵)의 Gemini 출력 구조에 맞춰 설계.
+-- 자주 필터/집계하는 필드는 정형 컬럼, 가변/리스트형은 JSONB.
+-- 독소조항(poison_clauses)은 항상 공고 단위 전체로 다뤄지므로 별도 테이블 대신 JSONB.
 CREATE TABLE analysis_results (
-    id                      SERIAL PRIMARY KEY,
-    notice_id               INTEGER         NOT NULL REFERENCES notices(id) ON DELETE CASCADE,
-    budget_amt              NUMERIC(18,2),
-    budget_raw              TEXT,
-    bid_qualify             TEXT,
-    exec_period_months      INTEGER,
-    exec_period_raw         TEXT,
-    manmonth_total          NUMERIC(8,2),
-    manmonth_detail         JSONB,
-    past_performance        TEXT,
-    eval_tech_score         NUMERIC(5,2),
-    eval_price_score        NUMERIC(5,2),
-    task_scope              TEXT,
-    joint_supply_yn         BOOLEAN,
-    joint_supply_detail     TEXT,
-    submit_deadline         TIMESTAMPTZ,
-    required_docs           JSONB,
-    exec_location           TEXT,
-    key_tech_spec           TEXT,
-    disqualify_reason       TEXT,
-    contact_person          JSONB,
-    confidence_score        NUMERIC(4,3),
-    model_used              VARCHAR(50),
-    prompt_version          VARCHAR(20),
-    analyzed_at             TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
-    updated_at              TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    id                  SERIAL PRIMARY KEY,
+    notice_id           INTEGER         NOT NULL REFERENCES notices(id) ON DELETE CASCADE,
+
+    -- 정형 (대시보드 필터/집계용)
+    project_type        VARCHAR(20),
+    estimated_price     BIGINT,
+    allocated_budget    BIGINT,
+    project_duration    VARCHAR(50),
+    contract_method     VARCHAR(100),
+    submit_deadline     TIMESTAMPTZ,
+    risk_level          VARCHAR(10)     CHECK (risk_level IN ('safe','warning','danger')),
+
+    -- 텍스트 / 반정형
+    issuing_org         TEXT,
+    project_summary     TEXT,
+    project_scope       TEXT,
+    qualification       TEXT,
+    eval_criteria       JSONB,
+    requirements        JSONB,
+    tech_requirements   JSONB,
+    poison_clauses      JSONB,
+
+    -- 메타
+    raw_analysis        JSONB,
+    model_used          VARCHAR(50),
+    prompt_version      VARCHAR(20),
+    analysis_status     VARCHAR(20)     NOT NULL DEFAULT 'pending'
+                            CHECK (analysis_status IN ('pending','processing','completed','failed')),
+    analyzed_at         TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
     UNIQUE (notice_id)
 );
 
 CREATE INDEX idx_analysis_notice_id ON analysis_results (notice_id);
-
-CREATE TABLE risk_factors (
-    id                      SERIAL PRIMARY KEY,
-    notice_id               INTEGER         NOT NULL REFERENCES notices(id) ON DELETE CASCADE,
-    risk_category           VARCHAR(50)     NOT NULL,
-    risk_level              VARCHAR(10)     NOT NULL DEFAULT 'medium' CHECK (risk_level IN ('high','medium','low')),
-    clause_title            VARCHAR(200),
-    clause_original         TEXT,
-    clause_summary          TEXT            NOT NULL,
-    page_no                 INTEGER,
-    mitigation_suggest      TEXT,
-    sort_order              INTEGER         NOT NULL DEFAULT 0,
-    created_at              TIMESTAMPTZ     NOT NULL DEFAULT NOW()
-);
-
-CREATE INDEX idx_risk_factors_notice_id  ON risk_factors (notice_id);
-CREATE INDEX idx_risk_factors_risk_level ON risk_factors (risk_level);
+CREATE INDEX idx_analysis_risk_level ON analysis_results (risk_level);
 
 CREATE TABLE proposal_outlines (
     id                      SERIAL PRIMARY KEY,

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -73,7 +73,7 @@ CREATE TABLE analysis_results (
     project_duration    VARCHAR(50),
     contract_method     VARCHAR(100),
     submit_deadline     TIMESTAMPTZ,
-    risk_level          VARCHAR(10)     CHECK (risk_level IN ('safe','warning','danger')),
+    risk_level          VARCHAR(10)     CHECK (risk_level IN ('safe','caution','warning','danger')),
 
     -- 텍스트 / 반정형
     issuing_org         TEXT,


### PR DESCRIPTION
## Summary
AI 분석 결과 저장 스키마(`analysis_results`)를 AI 파트의 Gemini 출력 구조에 맞춰 재설계하고, `risk_factors` 테이블을 `analysis_results.poison_clauses` (JSONB)로 통합합니다.

> ⚠️ 이 PR은 #27 (`feature/schema-cleanup`) 위에 stack되어 있습니다. #27 머지 후 base가 자동으로 develop으로 정리됩니다.

## 배경
AI 분석 파이프라인(강현묵 담당)의 Gemini 응답 구조가 기존 `analysis_results` 정형 컬럼(`eval_tech_score`, `manmonth_detail`, `exec_period_months` 등)과 1:1로 매핑되지 않았습니다. 기존 스키마에 억지로 맞추면 (a) 매핑 손실, (b) 의미 없는 NULL 컬럼 다수, (c) Gemini 원본 응답 유실이 발생합니다. AI 파트가 실제 산출하는 구조를 기준으로 컬럼을 재설계했습니다.

## 변경 내용

### `analysis_results` 재설계
- **정형 컬럼** (대시보드 필터/집계용): `project_type`, `estimated_price`, `allocated_budget`, `project_duration`, `contract_method`, `submit_deadline`, `risk_level`
- **텍스트/반정형**: `issuing_org`, `project_summary`, `project_scope`, `qualification`, `eval_criteria`(JSONB), `requirements`(JSONB), `tech_requirements`(JSONB), `poison_clauses`(JSONB)
- **메타**: `raw_analysis`(JSONB, 원본 응답 보존), `model_used`, `prompt_version`, `analysis_status`, `analyzed_at`, `updated_at`

### `risk_factors` 테이블 폐기 → `poison_clauses` JSONB 통합
#27의 `proposal_sections` 통합과 **동일한 사용-패턴 기준**입니다.

| 항목 | 독소조항(위험요소) 실제 사용 패턴 |
|---|---|
| 생성 | AI가 공고 단위로 한 번에 전체 산출 |
| 표시 | BidDetailPanel에서 한 공고의 전체를 일괄 렌더 |
| 부분 조회/편집 | 실수요 없음 |
| "high 등급 카운트" 등 집계 | `poison_clauses @> ...` JSONB Path + GIN 인덱스로 충분 |

row별로 부분 조회/편집되지 않는데 정규화 비용(JOIN, 별도 테이블 일관성 관리)만 짊어지는 구조라 JSONB가 적합합니다.

### 영향받은 코드
- `models.py`: `AnalysisResult` 재정의, `RiskFactor` 모델 + `Notice.risk_factors` 관계 삭제
- `crud.py`: `get_risk_factors_by_notice` / `create_risk_factors` 삭제, `selectinload(Notice.risk_factors)` 제거
- `routes/analysis.py`: GET 응답에서 `risk_factors` 키 제거 (이제 `analysis_result.poison_clauses`에 포함)
- `routes/bids.py`: `AnalysisResultSchema` 새 컬럼으로 재정의, `RiskFactorSchema` 삭제, `BidDetailResponse.risk_factors` 제거

## 호환성
- 현재 `analysis_results` / `risk_factors`에 실제 데이터가 적재되는 경로는 아직 없음 (analysis 라우트 미연결) → 무손실 변경
- **프론트 영향**: `services/api.ts`가 `res.risk_factors`를 읽던 부분을 `res.analysis_result.poison_clauses`로 바꿔야 함 → 후속 PR(#29, analyze_rfp 어댑팅 + 라우트 연결)에서 함께 보정 예정

## Test plan
- [x] `schema.sql` 적용 후 4개 테이블 확인 (risk_factors 부재)
- [x] `\d analysis_results`로 새 컬럼 + CHECK constraint 확인
- [x] `from backend.main import app` 임포트 통과
- [x] 잔여 `risk_factor` 참조 0건 (grep)

## Notes
- 후속 PR(#29): `analyze_rfp`가 이 스키마에 저장하도록 SQLAlchemy 어댑팅 + analysis 라우트 연결 + 프론트 매핑 보정
- 강주현님 — 이 재설계도 #27과 같은 RFC 성격입니다. 이견 있으시면 코멘트 부탁드려요

🤖 Generated with [Claude Code](https://claude.com/claude-code)