### PR TITLE
Feat: 영업담당자·담당 PM 저장 API 추가

### DIFF
--- a/backend/api/routes/bids.py
+++ b/backend/api/routes/bids.py
@@ -42,6 +42,7 @@ from backend.db.crud import (
     search_notices,
     set_bookmark,
     set_in_progress,
+    update_managers,
     upsert_memo,
 )
 from backend.db.database import get_db
@@ -131,6 +132,8 @@ class BidListItem(BaseModel):
     is_bookmarked: bool  # 관심 공고 여부
     is_in_progress: bool  # 진행 프로젝트 여부
     is_expired: bool = False  # 입찰마감일 경과 여부 (bid_clse_dt < 현재 KST)
+    sales_manager: str | None = None  # 영업담당자
+    project_pm: str | None = None  # 담당 PM
     presmpt_prce: float | None  # 추정가격
     asign_bdgt_amt: float | None  # 배정예산 (추정가격 없을 때 대체)
     bid_clse_dt: datetime | None  # 입찰마감일시
@@ -196,6 +199,8 @@ class BidDetailResponse(BaseModel):
     is_bookmarked: bool  # 관심 공고 여부
     is_in_progress: bool  # 진행 프로젝트 여부
     is_expired: bool = False  # 입찰마감일 경과 여부
+    sales_manager: str | None = None  # 영업담당자
+    project_pm: str | None = None  # 담당 PM
     asign_bdgt_amt: float | None
     presmpt_prce: float | None
     bid_clse_dt: datetime | None
@@ -396,6 +401,30 @@ async def toggle_in_progress(
 ) -> BidListItem:
     """공고 진행 여부를 설정한다. 진행 시 관심공고도 자동으로 설정된다."""
     notice = await set_in_progress(db, bid_ntce_no, is_in_progress)
+    if not notice:
+        raise HTTPException(status_code=404, detail="공고를 찾을 수 없습니다.")
+    return _to_list_item(notice)
+
+
+class ManagerUpdateRequest(BaseModel):
+    """영업담당자·담당 PM 업데이트 요청 스키마"""
+
+    sales_manager: str = ""
+    project_pm: str = ""
+
+
+@router.patch(
+    "/{bid_ntce_no}/managers",
+    summary="영업담당자·담당 PM 저장",
+    response_model=BidListItem,
+)
+async def update_bid_managers(
+    bid_ntce_no: str,
+    body: ManagerUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+) -> BidListItem:
+    """공고의 영업담당자와 담당 PM을 저장한다."""
+    notice = await update_managers(db, bid_ntce_no, body.sales_manager, body.project_pm)
     if not notice:
         raise HTTPException(status_code=404, detail="공고를 찾을 수 없습니다.")
     return _to_list_item(notice)

--- a/backend/db/crud.py
+++ b/backend/db/crud.py
@@ -178,6 +178,20 @@ async def set_in_progress(db: AsyncSession, bid_ntce_no: str, is_in_progress: bo
     return notice
 
 
+async def update_managers(
+    db: AsyncSession, bid_ntce_no: str, sales_manager: str, project_pm: str
+) -> Notice | None:
+    """공고의 영업담당자와 담당 PM을 저장한다."""
+    notice = await get_notice_detail(db, bid_ntce_no)
+    if not notice:
+        return None
+    notice.sales_manager = sales_manager or None
+    notice.project_pm = project_pm or None
+    await db.commit()
+    await db.refresh(notice)
+    return notice
+
+
 async def search_notices(db: AsyncSession, query: str, limit: int = 20) -> list[Notice]:
     """공고번호, 공고명, 기관명에서 query를 포함하는 공고를 반환한다. 최신 차수만 반환한다."""
     sq = _latest_ord_subquery()

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -34,6 +34,8 @@ class Notice(Base):
     pipeline_status:      Mapped[str]            = mapped_column(String(20), default="collected")
     is_bookmarked:        Mapped[bool]           = mapped_column(Boolean, default=False)
     is_in_progress:       Mapped[bool]           = mapped_column(Boolean, default=False)
+    sales_manager:        Mapped[Optional[str]]  = mapped_column(String(50), nullable=True)
+    project_pm:           Mapped[Optional[str]]  = mapped_column(String(50), nullable=True)
     parse_error_msg:      Mapped[Optional[str]]  = mapped_column(Text, nullable=True)
     content_embedding:    Mapped[Optional[list]] = mapped_column(Vector(1536), nullable=True)
     collected_at:         Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), nullable=True)


### PR DESCRIPTION
## 1.관련 이슈
closes #

## 2. 작업 내용
- `notices` 테이블에 `sales_manager`, `project_pm` 컬럼 추가 (ALTER TABLE 마이그레이션 완료)
- `crud.update_managers()` 함수 추가
- `PATCH /bids/{bid_ntce_no}/managers` 엔드포인트 추가
- `BidListItem`, `BidDetailResponse` 스키마에 두 필드 노출

## 3. 체크리스트
- [x] 코드 컨벤션을 준수했습니다
- [x] 셀프 리뷰를 완료했습니다
- [x] 테스트를 완료했습니다

## 4. 스크린샷 (선택)
